### PR TITLE
enh: remove pylink dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,7 @@ classifiers = [
 urls.homepage = "https://github.com/oesteban/psychopy-eyetracker-eyelink"
 urls.changelog = "https://github.com/oesteban/psychopy-eyetracker-eyelink/blob/main/CHANGELOG.txt"
 urls.repository = "https://github.com/oesteban/psychopy-eyetracker-eyelink"
-dependencies = [
-    "pylink"
-]
+dependencies = []
 [tool.setuptools.packages.find]
 where = ["", "psychopy_eyetracker_sr_research",]
 


### PR DESCRIPTION
It seems the standard `pylink` installation from the dependencies would not work. However, simply re-installing `pylink` with the proper version did not work as it was overwritting some of your code (don't know why but it raised an error looking like `pylink has no attribute 'eyelink'`).

So we had to first install a good version of pylink with:
``` shell
python3 -m pip install /usr/share/EyeLink/SampleExperiments/Python/wheels/sr_research_pylink-2.1.762.0-cp310-cp310-linux_x86_64.whl
```
then install your fix with no dependencies
``` shell
python3 -m pip install --no-deps git+https://github.com/oesteban/psychopy-eyetracker-eyelink.git
```